### PR TITLE
SUGGEST: generateFilePath flexible

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,18 @@ splitFileStream.mergeFilesToStream(filePaths, (outStream) => {
 });
 ```
 
+To split a read stream with a custom function that determines the file name:
+```javascript
+var splitFileStream = require("split-file-stream");
+let fileSize = 1024; // 1024 bytes per file
+let outputPaths = __dirname + "/outputFiles"; // file path partition's prefix
+var customSplit = splitFileStream.getSplitWithGenFilePath((r, n) => `${r}-${(n + 1)}`)
+
+customSplit(readStream, fileSize, outputPaths, (filePaths) => {
+	console.log("This is an array of my new files:" filePaths);
+});
+```
+
 Alternatively, if you'd like a lower level API for splitting a stream, you can use _splitToStream. This function will split your readable stream into multiple streams. This function is what is used to implement the split function.
 ```javascript
 var stream = require("stream");

--- a/index.js
+++ b/index.js
@@ -2,8 +2,6 @@ const fs = require("fs");
 const path = require("path");
 const stream = require("stream");
 
-const generateFilePath = (rootFileName, numFiles) => `${rootFileName}.split-${numFiles}`;
-
 const _mergeFiles = (partitionIndex, partitionNames, combinationStream, callback) => {
 	if(partitionIndex == partitionNames.length) {
 		combinationStream.end();
@@ -73,7 +71,11 @@ const _splitToStream = (outStreamCreate, fileStream, partitionStreamSize, callba
 	});
 };
 
-const split = (fileStream, maxFileSize, rootFilePath, callback) => {
+const split = (fileStream, maxFileSize, rootFilePath, callback) => _split(fileStream, maxFileSize, rootFilePath, (r, n) => `${r}.split-${n}`, callback);
+
+const getSplitWithGenFilePath = (generateFilePath) => ( (f, m, r, callback) => _split(f, m, r, generateFilePath, callback) )
+
+const _split = (fileStream, maxFileSize, rootFilePath, generateFilePath, callback) => {
 	const partitionNames = [];
 
 	const outStreamCreate = (partitionNum) => {
@@ -88,4 +90,5 @@ const split = (fileStream, maxFileSize, rootFilePath, callback) => {
 };
 
 module.exports.split = split;
+module.exports.getSplitWithGenFilePath = getSplitWithGenFilePath;
 module.exports._splitToStream = _splitToStream;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "split-file-stream",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -16,7 +16,7 @@
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
       "dev": true,
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -71,12 +71,12 @@
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "dev": true,
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "growl": {
@@ -103,8 +103,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -119,7 +119,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "1.1.8"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -167,7 +167,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "path-is-absolute": {
@@ -182,7 +182,7 @@
       "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
       "dev": true,
       "requires": {
-        "has-flag": "2.0.0"
+        "has-flag": "^2.0.0"
       }
     },
     "wrappy": {

--- a/test/merge.js
+++ b/test/merge.js
@@ -6,7 +6,7 @@ const splitFileStream = require("..");
 describe("#mergeFilesToDisk", () => {
 	it("Should merge 2 1mb partitions into one file", (done) => {
 		let readStream = new stream.PassThrough();
-		readStream.end(new Buffer(1024 * 1024 * 2));
+		readStream.end(new Buffer.alloc(1024 * 1024 * 2));
 
 		splitFileStream.split(readStream, 1024 * 1024 * 1, __dirname + "/output/ff", (filePaths) => {
 			assert.equal(2, filePaths.length);
@@ -24,7 +24,7 @@ describe("#mergeFilesToDisk", () => {
 describe("#mergeFilesToStream", () => {
 	it("Should merge 2 1mb partitions into one file stream", (done) => {
 		let readStream = new stream.PassThrough();
-		readStream.end(new Buffer(1024 * 1024 * 2));
+		readStream.end(new Buffer.alloc(1024 * 1024 * 2));
 
 		splitFileStream.split(readStream, 1024 * 1024 * 1, __dirname + "/output/ff", (filePaths) => {
 			assert.equal(2, filePaths.length);

--- a/test/split.js
+++ b/test/split.js
@@ -16,7 +16,7 @@ describe("#split", () => {
 
 	it("should create 2 partitions for 100mb file of 50mb chunks", (done) => {
 		let readStream = new stream.PassThrough();
-		readStream.end(new Buffer(1024 * 1024 * 100));
+		readStream.end(new Buffer.alloc(1024 * 1024 * 100));
 
 		splitFileStream.split(readStream, 1024 * 1024 * 50, __dirname + "/output/ff", (filePaths) => {
 			assert.equal(2, filePaths.length);


### PR DESCRIPTION
the method generateFilePath is hardcoded, which is quite unfortunate,
because it doesnt let you modify the filenames for the input.split-n files
(if you want to have say instead input-n as the filenames for splitted files)