### PR TITLE
Support for readable streams in object mode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,10 @@ var splitFileStream = require("split-file-stream");
 let maxFileSize = 1024; // 1024 bytes per file
 let outputPath = __dirname + "/outputFiles"; // file path partition's prefix
 
-splitFileStream.split(readStream, maxFileSize, outputPath, (filePaths) => {
+splitFileStream.split(readStream, maxFileSize, outputPath, (error, filePaths) => {
+	/* If an error occured, filePaths will still contain all files that were written */
+	if (error) throw error; // Alternatively you could just log the error instead of throwing: if (error) console.error(error)
+
 	console.log("This is an array of my new files:", filePaths);
 	/* stream will be saved to files in the path ∈ { ./outputFiles.split-x | x ∈ N } */
 });
@@ -78,7 +81,10 @@ let maxFileSize = 1024; // 1024 bytes per file
 let outputPath = __dirname + "/outputFiles"; // file path partition's prefix
 var customSplit = splitFileStream.getSplitWithGenFilePath((n) => `${outputPath}-${(n + 1)}`)
 
-customSplit(readStream, maxFileSize, (filePaths) => {
+customSplit(readStream, maxFileSize, (error, filePaths) => {
+	/* If an error occured, filePaths will still contain all files that were written */
+	if (error) throw error; // Alternatively you could just log the error instead of throwing: if (error) console.error(error)
+
 	console.log("This is an array of my new files:", filePaths);
 });
 ```
@@ -92,7 +98,10 @@ const outStreamCreate = (partitionNum) => {
 	return stream.passThrough();
 };
 
-splitFileStream._splitToStream(outStreamCreate, readStream, partitionStreamSize, (outStreams) => {
+splitFileStream._splitToStream(outStreamCreate, readStream, partitionStreamSize, (error, outStreams) => {
+	/* If an error occured, filePaths will still contain all files that were written */
+	if (error) throw error; // Alternatively you could just log the error instead of throwing: if (error) console.error(error)
+
 	console.log("This is an array of the created output streams:", outStreams);
 });
 ```

--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ const _splitToStream = (outStreamCreate, fileStream, partitionStreamSize, callba
 	const writeStreamFinishHandler = () => {
 		finishedWriteStreams++;
 		if (fileStreamEnded && partitionNum == finishedWriteStreams) {
-			callback(outStreams, err);
+			callback(err, outStreams);
 		}
 	};
 
@@ -105,9 +105,9 @@ const _split = (fileStream, maxFileSize, generateFilePath, callback) => {
 		let filePath = generateFilePath(partitionNum);
 		return fs.createWriteStream(filePath);
 	};
-	_splitToStream(outStreamCreate, fileStream, maxFileSize, (fileWriteStreams, err) => {
+	_splitToStream(outStreamCreate, fileStream, maxFileSize, (err, fileWriteStreams) => {
 		fileWriteStreams.forEach((fileWriteStream) => partitionNames.push(fileWriteStream["path"]));
-		callback(partitionNames, err);
+		callback(err, partitionNames);
 	});
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "split-file-stream",
-  "version": "1.3.0",
+  "version": "2.0.0",
   "description": "Partition your readable streams into multiple files.",
   "main": "index.js",
   "scripts": {
@@ -8,7 +8,11 @@
   },
   "keywords": [
     "File Partitioning",
-    "streams"
+    "streams",
+    "split stream",
+    "merge stream",
+    "split",
+    "merge"
   ],
   "repository": {
     "type": "git",

--- a/test/merge.js
+++ b/test/merge.js
@@ -20,7 +20,8 @@ describe("#mergeFilesToDisk", () => {
 		let readStream = new stream.PassThrough();
 		readStream.end(new Buffer.alloc(1024 * 1024 * 2));
 
-		splitFileStream.split(readStream, 1024 * 1024 * 1, __dirname + "/output/ff", (filePaths, err) => {
+		splitFileStream.split(readStream, 1024 * 1024 * 1, __dirname + "/output/ff", (err, filePaths) => {
+			assert.strictEqual(null, err);
 			assert.strictEqual(2, filePaths.length);
 			let mergeFilePath = __dirname + "/output/ff.fullfile";
 			splitFileStream.mergeFilesToDisk(filePaths, mergeFilePath, () => {
@@ -38,7 +39,8 @@ describe("#mergeFilesToStream", () => {
 		let readStream = new stream.PassThrough();
 		readStream.end(new Buffer.alloc(1024 * 1024 * 2));
 
-		splitFileStream.split(readStream, 1024 * 1024 * 1, __dirname + "/output/ff", (filePaths, err) => {
+		splitFileStream.split(readStream, 1024 * 1024 * 1, __dirname + "/output/ff", (err, filePaths) => {
+			assert.strictEqual(null, err);
 			assert.strictEqual(2, filePaths.length);
 			let mergeFilePath = __dirname + "/output/ff.fullfile";
 			splitFileStream.mergeFilesToStream(filePaths, (stream) => {

--- a/test/merge.js
+++ b/test/merge.js
@@ -20,7 +20,7 @@ describe("#mergeFilesToDisk", () => {
 		let readStream = new stream.PassThrough();
 		readStream.end(new Buffer.alloc(1024 * 1024 * 2));
 
-		splitFileStream.split(readStream, 1024 * 1024 * 1, __dirname + "/output/ff", (filePaths) => {
+		splitFileStream.split(readStream, 1024 * 1024 * 1, __dirname + "/output/ff", (filePaths, err) => {
 			assert.strictEqual(2, filePaths.length);
 			let mergeFilePath = __dirname + "/output/ff.fullfile";
 			splitFileStream.mergeFilesToDisk(filePaths, mergeFilePath, () => {
@@ -38,7 +38,7 @@ describe("#mergeFilesToStream", () => {
 		let readStream = new stream.PassThrough();
 		readStream.end(new Buffer.alloc(1024 * 1024 * 2));
 
-		splitFileStream.split(readStream, 1024 * 1024 * 1, __dirname + "/output/ff", (filePaths) => {
+		splitFileStream.split(readStream, 1024 * 1024 * 1, __dirname + "/output/ff", (filePaths, err) => {
 			assert.strictEqual(2, filePaths.length);
 			let mergeFilePath = __dirname + "/output/ff.fullfile";
 			splitFileStream.mergeFilesToStream(filePaths, (stream) => {

--- a/test/merge.js
+++ b/test/merge.js
@@ -21,11 +21,11 @@ describe("#mergeFilesToDisk", () => {
 		readStream.end(new Buffer.alloc(1024 * 1024 * 2));
 
 		splitFileStream.split(readStream, 1024 * 1024 * 1, __dirname + "/output/ff", (filePaths) => {
-			assert.equal(2, filePaths.length);
+			assert.strictEqual(2, filePaths.length);
 			let mergeFilePath = __dirname + "/output/ff.fullfile";
 			splitFileStream.mergeFilesToDisk(filePaths, mergeFilePath, () => {
 				fs.stat(mergeFilePath, (err, stats) => {
-					assert.equal(1024 * 1024 * 2, stats.size);
+					assert.strictEqual(1024 * 1024 * 2, stats.size);
 					return done();
 				});
 			});
@@ -39,7 +39,7 @@ describe("#mergeFilesToStream", () => {
 		readStream.end(new Buffer.alloc(1024 * 1024 * 2));
 
 		splitFileStream.split(readStream, 1024 * 1024 * 1, __dirname + "/output/ff", (filePaths) => {
-			assert.equal(2, filePaths.length);
+			assert.strictEqual(2, filePaths.length);
 			let mergeFilePath = __dirname + "/output/ff.fullfile";
 			splitFileStream.mergeFilesToStream(filePaths, (stream) => {
 				let dataLength = 0;
@@ -48,7 +48,7 @@ describe("#mergeFilesToStream", () => {
 				});
 
 				stream.on("finish", () => {
-					assert.equal(dataLength, 1024 * 1024 * 2);
+					assert.strictEqual(dataLength, 1024 * 1024 * 2);
 					return done();
 				});
 			});

--- a/test/split.js
+++ b/test/split.js
@@ -20,7 +20,7 @@ describe("#split", () => {
 		let readStream = new stream.PassThrough();
 		readStream.end("abcde");
 
-		splitFileStream.split(readStream, 1, __dirname + "/output/ff", (filePaths) => {
+		splitFileStream.split(readStream, 1, __dirname + "/output/ff", (filePaths, err) => {
 			assert.strictEqual(5, filePaths.length);
 			return done();
 		});
@@ -30,7 +30,7 @@ describe("#split", () => {
 		let readStream = new stream.PassThrough();
 		readStream.end(new Buffer.alloc(1024 * 1024 * 100));
 
-		splitFileStream.split(readStream, 1024 * 1024 * 50, __dirname + "/output/ff", (filePaths) => {
+		splitFileStream.split(readStream, 1024 * 1024 * 50, __dirname + "/output/ff", (filePaths, err) => {
 			assert.strictEqual(2, filePaths.length);
 			return done();
 		});
@@ -40,7 +40,7 @@ describe("#split", () => {
 		let readStream = new stream.PassThrough(), inStreamContents = "CORRECT";
 		readStream.end(inStreamContents);
 
-		splitFileStream.split(readStream, 1, __dirname + "/output/ff", (filePaths) => {
+		splitFileStream.split(readStream, 1, __dirname + "/output/ff", (filePaths, err) => {
 			let concatString = "";
 			filePaths.forEach((filePath) => {
 				let fileContent = fs.readFileSync(filePath);
@@ -60,7 +60,7 @@ describe("#split", () => {
 		let expectedFilePaths = Array.apply(null, Array(7)).map((v, i) => `${outputPath}-${i + 1}`);
 		var customSplit = splitFileStream.getSplitWithGenFilePath((n) => `${outputPath}-${(n + 1)}`)
 
-		customSplit(readStream, 1, (filePaths) => {
+		customSplit(readStream, 1, (filePaths, err) => {
 			assert.strictEqual(filePaths.length, 7);
 			assert.deepStrictEqual(filePaths, expectedFilePaths);
 
@@ -71,6 +71,100 @@ describe("#split", () => {
 			});
 
 			assert.strictEqual(concatString, inStreamContents);
+			return done();
+		});
+	});
+
+	it("should support stringifying objectMode", (done) => {
+		let readStream = new stream.Readable({
+			objectMode: true,
+			read() { }
+		}).pipe(new stream.PassThrough({ objectMode: true }));
+		readStream.push({ qr: 'st' }) // 1 object is 11 bytes (2 bytes per character, including { })
+		readStream.push({ uv: 'wx' })
+		readStream.push(null) // end readStream
+		splitFileStream.split(readStream, 22, __dirname + "/output/ff", (filePaths, err) => {
+			assert.strictEqual(1, filePaths.length);
+			return done();
+		});
+	});
+
+	it("should throw on objects larger than maxFileSize in stringifying objectMode", (done) => {
+		let readStream = new stream.Readable({
+			objectMode: true,
+			read() { }
+		}).pipe(new stream.PassThrough({ objectMode: true }));
+		readStream.push({ ab: 'cd' }) // 11 bytes (2 bytes per character, including { })
+		readStream.push({ ef: 'ghi' }) // 12 bytes (2 bytes per character, including { })
+		readStream.push(null) // end readStream
+
+		splitFileStream.split(readStream, 11, __dirname + "/output/ff", (filePaths, err) => {
+			assert.strictEqual(2, filePaths.length);
+			const {size: fileSize} = fs.statSync(filePaths[0]);
+			assert.strictEqual(11, fileSize);
+			const {size: fileSize2} = fs.statSync(filePaths[1]);
+			assert.strictEqual(0, fileSize2);
+			assert.notStrictEqual(err, null);
+			var passErr = function(err) { throw err }
+			assert.throws(function() { passErr(err) }, RangeError)
+			done();
+		})
+	});
+
+	it("should split for objects larger than maxFileSize in stringifying objectMode", (done) => {
+		let readStream = new stream.Readable({
+			objectMode: true,
+			read() { }
+		}).pipe(new stream.PassThrough({ objectMode: true }));
+		readStream.push({ ab: 'cd' }) // 11 bytes (2 bytes per character, including { })
+		readStream.push({ ef: 'ghi' }) // 12 bytes (2 bytes per character, including { })
+		readStream.push(null) // end readStream
+
+		splitFileStream.split(readStream, 22, __dirname + "/output/ff", (filePaths, err) => {
+			assert.strictEqual(2, filePaths.length);
+			const {size: fileSize} = fs.statSync(filePaths[0]);
+			assert.strictEqual(11, fileSize);
+			const {size: fileSize2} = fs.statSync(filePaths[1]);
+			assert.strictEqual(12, fileSize2);
+			assert.strictEqual(err, null);
+			done();
+		})
+	});
+
+	it("should respect maxFileSize in readable stream in objectMode with object size matching", (done) => {
+		const myTransform = new stream.Transform({
+			objectMode: true,
+			transform(chunk, encoding, callback) {
+				// Push the data onto the readable queue.
+				callback(null, Object.keys(chunk) + Object.values(chunk)); // concatenate key+value
+			}
+		});
+
+		const readStream = new stream.Readable({ objectMode: true, read: () => { } })
+		readStream.push({ ij: 'kl' }) // 1 object is 8 bytes (2 byter per character, as concatenated by Transform)
+		readStream.push({ mn: 'op' })
+		readStream.push(null) // end readStream
+		splitFileStream.split(readStream.pipe(myTransform), 8, __dirname + "/output/ff", (filePaths, err) => {
+			assert.strictEqual(2, filePaths.length);
+			return done();
+		});
+	});
+
+	it("should respect maxFileSize in readable stream in objectMode with object size unmatched", (done) => {
+		const myTransform = new stream.Transform({
+			objectMode: true,
+			transform(chunk, encoding, callback) {
+				// Push the data onto the readable queue.
+				callback(null, Object.keys(chunk) + Object.values(chunk)); // concatenate key+value
+			}
+		});
+
+		const readStream = new stream.Readable({ objectMode: true, read: () => { } })
+		readStream.push({ ij: 'kl' }) // 1 object is 8 bytes (2 byter per character, as concatenated by Transform)
+		readStream.push({ mn: 'op' })
+		readStream.push(null) // end readStream
+		splitFileStream.split(readStream.pipe(myTransform), 9, __dirname + "/output/ff", (filePaths, err) => {
+			assert.strictEqual(2, filePaths.length);
 			return done();
 		});
 	});

--- a/test/split.js
+++ b/test/split.js
@@ -21,7 +21,7 @@ describe("#split", () => {
 		readStream.end("abcde");
 
 		splitFileStream.split(readStream, 1, __dirname + "/output/ff", (filePaths) => {
-			assert.equal(5, filePaths.length);
+			assert.strictEqual(5, filePaths.length);
 			return done();
 		});
 	});
@@ -31,7 +31,7 @@ describe("#split", () => {
 		readStream.end(new Buffer.alloc(1024 * 1024 * 100));
 
 		splitFileStream.split(readStream, 1024 * 1024 * 50, __dirname + "/output/ff", (filePaths) => {
-			assert.equal(2, filePaths.length);
+			assert.strictEqual(2, filePaths.length);
 			return done();
 		});
 	});
@@ -47,7 +47,7 @@ describe("#split", () => {
 				concatString += fileContent;
 			});
 
-			assert.equal(concatString, inStreamContents);
+			assert.strictEqual(concatString, inStreamContents);
 			return done();
 		});
 	});
@@ -61,8 +61,8 @@ describe("#split", () => {
 		var customSplit = splitFileStream.getSplitWithGenFilePath((n) => `${outputPath}-${(n + 1)}`)
 
 		customSplit(readStream, 1, (filePaths) => {
-			assert.equal(filePaths.length, 7);
-			assert.deepEqual(filePaths, expectedFilePaths);
+			assert.strictEqual(filePaths.length, 7);
+			assert.deepStrictEqual(filePaths, expectedFilePaths);
 
 			let concatString = "";
 			filePaths.forEach((filePath) => {
@@ -70,7 +70,7 @@ describe("#split", () => {
 				concatString += fileContent;
 			});
 
-			assert.equal(concatString, inStreamContents);
+			assert.strictEqual(concatString, inStreamContents);
 			return done();
 		});
 	});

--- a/test/split.js
+++ b/test/split.js
@@ -20,7 +20,8 @@ describe("#split", () => {
 		let readStream = new stream.PassThrough();
 		readStream.end("abcde");
 
-		splitFileStream.split(readStream, 1, __dirname + "/output/ff", (filePaths, err) => {
+		splitFileStream.split(readStream, 1, __dirname + "/output/ff", (err, filePaths) => {
+			assert.strictEqual(null, err);
 			assert.strictEqual(5, filePaths.length);
 			return done();
 		});
@@ -30,7 +31,8 @@ describe("#split", () => {
 		let readStream = new stream.PassThrough();
 		readStream.end(new Buffer.alloc(1024 * 1024 * 100));
 
-		splitFileStream.split(readStream, 1024 * 1024 * 50, __dirname + "/output/ff", (filePaths, err) => {
+		splitFileStream.split(readStream, 1024 * 1024 * 50, __dirname + "/output/ff", (err, filePaths) => {
+			assert.strictEqual(null, err);
 			assert.strictEqual(2, filePaths.length);
 			return done();
 		});
@@ -40,7 +42,8 @@ describe("#split", () => {
 		let readStream = new stream.PassThrough(), inStreamContents = "CORRECT";
 		readStream.end(inStreamContents);
 
-		splitFileStream.split(readStream, 1, __dirname + "/output/ff", (filePaths, err) => {
+		splitFileStream.split(readStream, 1, __dirname + "/output/ff", (err, filePaths) => {
+			assert.strictEqual(null, err);
 			let concatString = "";
 			filePaths.forEach((filePath) => {
 				let fileContent = fs.readFileSync(filePath);
@@ -60,7 +63,8 @@ describe("#split", () => {
 		let expectedFilePaths = Array.apply(null, Array(7)).map((v, i) => `${outputPath}-${i + 1}`);
 		var customSplit = splitFileStream.getSplitWithGenFilePath((n) => `${outputPath}-${(n + 1)}`)
 
-		customSplit(readStream, 1, (filePaths, err) => {
+		customSplit(readStream, 1, (err, filePaths) => {
+			assert.strictEqual(null, err);
 			assert.strictEqual(filePaths.length, 7);
 			assert.deepStrictEqual(filePaths, expectedFilePaths);
 
@@ -83,7 +87,8 @@ describe("#split", () => {
 		readStream.push({ qr: 'st' }) // 1 object is 11 bytes (2 bytes per character, including { })
 		readStream.push({ uv: 'wx' })
 		readStream.push(null) // end readStream
-		splitFileStream.split(readStream, 22, __dirname + "/output/ff", (filePaths, err) => {
+		splitFileStream.split(readStream, 22, __dirname + "/output/ff", (err, filePaths) => {
+			assert.strictEqual(null, err);
 			assert.strictEqual(1, filePaths.length);
 			return done();
 		});
@@ -98,7 +103,7 @@ describe("#split", () => {
 		readStream.push({ ef: 'ghi' }) // 12 bytes (2 bytes per character, including { })
 		readStream.push(null) // end readStream
 
-		splitFileStream.split(readStream, 11, __dirname + "/output/ff", (filePaths, err) => {
+		splitFileStream.split(readStream, 11, __dirname + "/output/ff", (err, filePaths) => {
 			assert.strictEqual(2, filePaths.length);
 			const {size: fileSize} = fs.statSync(filePaths[0]);
 			assert.strictEqual(11, fileSize);
@@ -120,7 +125,7 @@ describe("#split", () => {
 		readStream.push({ ef: 'ghi' }) // 12 bytes (2 bytes per character, including { })
 		readStream.push(null) // end readStream
 
-		splitFileStream.split(readStream, 22, __dirname + "/output/ff", (filePaths, err) => {
+		splitFileStream.split(readStream, 22, __dirname + "/output/ff", (err, filePaths) => {
 			assert.strictEqual(2, filePaths.length);
 			const {size: fileSize} = fs.statSync(filePaths[0]);
 			assert.strictEqual(11, fileSize);
@@ -144,7 +149,8 @@ describe("#split", () => {
 		readStream.push({ ij: 'kl' }) // 1 object is 8 bytes (2 byter per character, as concatenated by Transform)
 		readStream.push({ mn: 'op' })
 		readStream.push(null) // end readStream
-		splitFileStream.split(readStream.pipe(myTransform), 8, __dirname + "/output/ff", (filePaths, err) => {
+		splitFileStream.split(readStream.pipe(myTransform), 8, __dirname + "/output/ff", (err, filePaths) => {
+			assert.strictEqual(null, err);
 			assert.strictEqual(2, filePaths.length);
 			return done();
 		});
@@ -163,7 +169,8 @@ describe("#split", () => {
 		readStream.push({ ij: 'kl' }) // 1 object is 8 bytes (2 byter per character, as concatenated by Transform)
 		readStream.push({ mn: 'op' })
 		readStream.push(null) // end readStream
-		splitFileStream.split(readStream.pipe(myTransform), 9, __dirname + "/output/ff", (filePaths, err) => {
+		splitFileStream.split(readStream.pipe(myTransform), 9, __dirname + "/output/ff", (err, filePaths) => {
+			assert.strictEqual(null, err);
 			assert.strictEqual(2, filePaths.length);
 			return done();
 		});


### PR DESCRIPTION
I was using your library with a stream in object mode (for which it is important to keep a blob of data (object) together).

In this case a `stream.read(size)` ignores its `size` parameter, and just returns one object.
(Quoted documentation: _A Readable stream in object mode will always return a single item from a call to readable.read(size), regardless of the value of the size argument._)

In this case, it is likely that the partition size is larger than exactly specified. Do end the current write stream in this case as well.